### PR TITLE
make hex gameboard more legible

### DIFF
--- a/src/main/java/com/github/sandorw/mocabogaso/games/hex/HexGameState.java
+++ b/src/main/java/com/github/sandorw/mocabogaso/games/hex/HexGameState.java
@@ -43,7 +43,7 @@ public final class HexGameState implements GameState<DefaultGameMove, DefaultGam
         @Override
         public String toString() {
             if (this == EMPTY)
-                return " ";
+                return ".";
             if (this == X)
                 return "X";
             return "O";


### PR DESCRIPTION
Making empty spaces print as "." makes the board much more legible:

```
HexGameState, board size=9
  A B C D E F G H I
 9 . . . . . . . O X
  8 . . . . . . X O .
   7 . . . . . . O . .
    6 . . . . . X O . .
     5 . . . . X O . . .
      4 . . . X O X . . .
       3 . . . X O . . . .
        2 . . . X . . . . .
         1 . . . . . . . . .
            A B C D E F G H I
```